### PR TITLE
Remove copyright notice from pastlink.php

### DIFF
--- a/pastlink.php
+++ b/pastlink.php
@@ -1,7 +1,7 @@
 ﻿<?php
 /*====================================================================================================================*\
   PastLink - HTTP Server for manipulating ALTTP Randomizer on BizHawk
-  (c) Copyright 2021 Phillip Shaw (HatchlingByHeart)
+  Author: Phillip Shaw (HatchlingByHeart)
 \*====================================================================================================================*/
 
 require_once "config.php";


### PR DESCRIPTION
This is an error, and does not match the LICENSE file.
HatchlingByHeart has given permission to make this change.